### PR TITLE
manifest: add new omap4 hardware repo for current device

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -385,6 +385,7 @@
   <project path="hardware/ril-caf" name="SlimRoms/hardware_ril" remote="github" revision="lp5.1-caf" />
   <project path="hardware/samsung_slsi/exynos5" name="SlimRoms/hardware_samsung_slsi_exynos5" remote="github" revision="lp5.1" />
   <project path="hardware/ti/omap3" name="SlimRoms/hardware_ti_omap3" remote="github" revision="lp5.1" />
+  <project path="hardware/ti/omap4" name="SlimRoms/hardware_ti_omap4" remote="github" revision="lp5.1" />
   <project path="hardware/ti/omap4xxx" name="SlimRoms/hardware_ti_omap4xxx" remote="github" revision="lp5.1" />
   <project path="hardware/ti/wlan" name="SlimRoms/hardware_ti_wlan" remote="github" revision="lp5.1" />
   <project path="hardware/ti/wpan" name="SlimRoms/hardware_ti_wpan" remote="github" revision="lp5.1" />


### PR DESCRIPTION
 support

This repo is for devices using a kernel based on omapzoom 3.0.31 release.

Includes many updates for versions of Android which were not originally
supported by TI (beyond JBMR0):
- camera compatibilty updates
- DOMX updates and removal of duplicated OMX headers
- PVR-source is DDK 1.9@2291151
- and more

Change-Id: Ic6958751ce18e0140751a28eb1e13270d8e688a1
Signed-off-by: Hashcode <hashcode0f@gmail.com>